### PR TITLE
Compatibility Update for Thunderbird 128

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,5 +1,4 @@
 const {ExtensionCommon} = ChromeUtils.import('resource://gre/modules/ExtensionCommon.jsm')
-const {Services} = ChromeUtils.import('resource://gre/modules/Services.jsm')
 const {ExtensionSupport} = ChromeUtils.import('resource:///modules/ExtensionSupport.jsm')
 
 
@@ -33,8 +32,7 @@ function registerOnColorPicker(context)
 
     ExtensionSupport.registerWindowListener(context.extension.addonData.id, {
         chromeURLs: [
-            'chrome://editor/content/EdColorPicker.xul', // TB 68
-            'chrome://messenger/content/messengercompose/EdColorPicker.xhtml' // TB 78
+            'chrome://messenger/content/messengercompose/EdColorPicker.xhtml'
         ],
         onLoadWindow() {
             colorBefore = getLastTextColor()

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -7,7 +7,8 @@
     "applications": {
         "gecko": {
             "id": "previous-colors@alkatrazstudio.net",
-            "strict_min_version": "68.0"
+            "strict_min_version": "115.0",
+            "strict_max_version": "128.*"
         }
     },
     "experiment_apis": {


### PR DESCRIPTION
The file Services.jsm no longer exists in Thunderbird 128 and loading it causes the add-on to fail.